### PR TITLE
Use POSIX shell script syntax for portability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
-#! /bin/sh
+#!/bin/sh
 
-if [[ "$HPHP_HOME" == "" ]]; then
-    echo HPHP_HOME environment variable must be set!
+if [ "$HPHP_HOME" = "" ]; then
+    echo "HPHP_HOME environment variable must be set!"
     exit 1
 fi
 


### PR DESCRIPTION
Ubuntu happens to use Dash as its shell, which lacks some Bash syntax found in most shells. The `[[` conditional syntax would throw an error. The POSIX-compatible syntax is `[` and a `=` equality test instead of `==`. Additional info: https://wiki.ubuntu.com/DashAsBinSh