### PR TITLE
Support building against specific HHVM version

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,16 +1,13 @@
 #! /bin/sh
 
-if [ "`which hphpize 2>/dev/null`" != "" ]; then
-    # HHVM 3.2.0 or newer
+if [ "$HPHP_HOME" != "" ]; then
+    echo "Using HPHP_HOME $HPHP_HOME"
+    /bin/sh $HPHP_HOME/hphp/tools/hphpize/hphpize
+elif [ "`which hphpize 2>/dev/null`" != "" ]; then
     hphpize
 else
-    # HHVM older than 3.2.0
-    if [ "$HPHP_HOME" == "" ]; then
-        echo HPHP_HOME environment variable must be set!
-        exit 1
-    fi
-
-    $HPHP_HOME/hphp/tools/hphpize/hphpize
+    echo "HPHP_HOME environment variable must be set!"
+    exit 1
 fi
 
 cmake . && make

--- a/example.cpp
+++ b/example.cpp
@@ -14,7 +14,7 @@
    +----------------------------------------------------------------------+
 */
 
-#include "hphp/runtime/base/base-includes.h"
+#include "hphp/runtime/ext/extension.h"
 
 namespace HPHP {
 


### PR DESCRIPTION
This allows to specify `HPHP_HOME` also for the new HHVM versions. Useful when you want to test extension against different versions of HHVM, built on the same machine, not only the default one installed by the package manager. One may want to do it as HHVM breaks compatibility with extensions from time to time.